### PR TITLE
Update build_deps.sh

### DIFF
--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # The MIT License
 #


### PR DESCRIPTION
Move `/bin/bash` to `/usr/bin/env bash` so that the build script works with systems that do not have their bash installed in `/bin`.
